### PR TITLE
Fixed clipboard table empty error

### DIFF
--- a/lua/ghengis.lua
+++ b/lua/ghengis.lua
@@ -102,7 +102,9 @@ function M.moveSelectionToNewFile() fileOp("newFromSel") end
 ---copying file information
 ---@param operation string filename|filepath
 local function copyOp(operation)
-	local useSystemClipb = vim.opt.clipboard:get()[1]:find("unnamed")
+	local useSystemClipb = false
+	local clipboard = vim.opt.clipboard:get();
+	if #clipboard ~= 0 then useSystemClipb = clipboard[1]:find("unnamed") end
 	local reg = '"'
 	if useSystemClipb then reg = "+" end
 


### PR DESCRIPTION
If `clipboard` wasn't set to anything, the `vim.opt.clipboard:get()` table was empty, and `[1]` was a nil value, so `:find("unnamed")` threw an error